### PR TITLE
fix blank message from newline

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ a{
      $.get('valentines.txt', function(v){
           text = v.split("\n")
           for (var i = 0; i < text.length; i++) {
-            message.push (text[i])
+            if (text[i] !== "") message.push(text[i])
           }
           newValentine()
         })


### PR DESCRIPTION
Sometimes the message is blank because `message[Math.floor(Math.random() * message.length)]` can equal zero. I put a `+ 1` in there, should work flawlessly now.

What would an ocean be without a monster lurking in the dark? It would be like sleep without dreams.
